### PR TITLE
Remove cache of configurations and use ActiveRecord::configurations

### DIFF
--- a/lib/phenix.rb
+++ b/lib/phenix.rb
@@ -53,7 +53,7 @@ module Phenix
   end
 
   def for_each_database
-    Phenix.current_configuration.each do |name, conf|
+    ActiveRecord::Base.configurations.each do |name, conf|
       next if conf['database'].nil?
       next if Phenix.skip_database.call(name, conf)
       yield(name, conf)


### PR DESCRIPTION
:octopus::computer:

/cc @bquorning @grosser 

### Description
With ActiveRecordShards, ActiveRecord::Base.configurations and Phenix.current_configuration end up different since the gem monkey patches the former. This removed the unnecessary cache.

### Steps to merge
* [ ] :+1: from the team

### Risks
* None