### PR TITLE
Rails 6.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,32 @@ sudo: false
 cache: bundler
 bundler_args: --no-deployment
 language: ruby
+services: mysql
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
+  - 2.5
+  - 2.6
 gemfile:
-  - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
+  - gemfiles/rails6.0.gemfile
 branches:
   only: master
+matrix:
+  exclude:
+    - rvm: 2.4
+      gemfile: gemfiles/rails6.0.gemfile
+    - rvm: 2.5
+      gemfile: gemfiles/rails4.2.gemfile
+    - rvm: 2.5
+      gemfile: gemfiles/rails5.0.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails4.2.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails5.0.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails5.1.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails5.2.gemfile

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 3.2.22'
-gem 'mysql2', '~> 0.3.20'
+gem 'activerecord', '~> 6.0.0'
 
 eval_gemfile 'common.rb'

--- a/lib/phenix.rb
+++ b/lib/phenix.rb
@@ -64,7 +64,7 @@ module Phenix
   end
 
   def for_each_database
-    ActiveRecord::Base.configurations.each do |name, conf|
+    ActiveRecord::Base.configurations.to_h.each do |name, conf|
       next if conf['database'].nil?
       next if Phenix.skip_database.call(name, conf)
       yield(name, conf)

--- a/phenix.gemspec
+++ b/phenix.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'bundler'
-  s.add_dependency 'activerecord', '>= 3.2', '< 6.0 '
+  s.add_dependency 'activerecord', '>= 4.2', '< 6.1'
 
   s.add_development_dependency 'rake', '~> 10.5'
   s.add_development_dependency 'rspec', '~> 3.4'

--- a/spec/phenix_spec.rb
+++ b/spec/phenix_spec.rb
@@ -29,7 +29,6 @@ describe Phenix do
   let(:complex_database_path) { File.join(test_directory, 'complex_database.yml') }
 
   let(:exists_method)  { (ActiveRecord::VERSION::MAJOR < 5 ? :table_exists? : :data_source_exists?) }
-  let(:database_error) { (ActiveRecord::VERSION::MAJOR < 4 ? Mysql2::Error : ActiveRecord::NoDatabaseError) }
 
   before { Phenix.configure }
 
@@ -94,7 +93,7 @@ describe Phenix do
 
       it 'creates the databases' do
         ActiveRecord::Base.establish_connection(:database2)
-        expect { ActiveRecord::Base.connection }.to raise_error(database_error)
+        expect { ActiveRecord::Base.connection }.to raise_error(ActiveRecord::NoDatabaseError)
 
         create_databases(false)
 
@@ -184,7 +183,7 @@ describe Phenix do
       expect(current_database).to eq('phenix_database_2')
 
       ActiveRecord::Base.establish_connection(:database3)
-      expect { ActiveRecord::Base.connection }.to raise_error(database_error)
+      expect { ActiveRecord::Base.connection }.to raise_error(ActiveRecord::NoDatabaseError)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'bundler/setup'
 require 'single_cov'
-SingleCov.setup :rspec
+SingleCov.setup :rspec, branches: false
 
 require 'phenix'


### PR DESCRIPTION
* Add support for Rails 6.0
* Drop support for Rails 3.2
* Start testing against modern Rubies: 2.5 and 2.6.
* Stop testing against EOL Rubies: 2.2. and 2.3.