### PR TITLE
Add compatibility with Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,31 +3,18 @@ cache: bundler
 bundler_args: --no-deployment
 language: ruby
 services: mysql
-rvm:
-  - 2.4
-  - 2.5
-  - 2.6
+rvm: 2.7
 gemfile:
-  - gemfiles/rails4.2.gemfile
-  - gemfiles/rails5.0.gemfile
-  - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
   - gemfiles/rails6.0.gemfile
+  - gemfiles/rails6.1.gemfile
 branches:
   only: master
 matrix:
-  exclude:
-    - rvm: 2.4
-      gemfile: gemfiles/rails6.0.gemfile
+  include:
     - rvm: 2.5
       gemfile: gemfiles/rails4.2.gemfile
     - rvm: 2.5
       gemfile: gemfiles/rails5.0.gemfile
-    - rvm: 2.6
-      gemfile: gemfiles/rails4.2.gemfile
-    - rvm: 2.6
-      gemfile: gemfiles/rails5.0.gemfile
-    - rvm: 2.6
+    - rvm: 2.5
       gemfile: gemfiles/rails5.1.gemfile
-    - rvm: 2.6
-      gemfile: gemfiles/rails5.2.gemfile

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 6.1.0.rc1'
+
+eval_gemfile 'common.rb'

--- a/phenix.gemspec
+++ b/phenix.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bundler'
   s.add_dependency 'activerecord', '>= 4.2', '< 6.1'
 
-  s.add_development_dependency 'rake', '~> 10.5'
+  s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'wwtd'
   s.add_development_dependency 'bump'

--- a/spec/phenix_spec.rb
+++ b/spec/phenix_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'active_record'
 require 'tmpdir'
 
-SingleCov.covered!
+SingleCov.covered! uncovered: (ActiveRecord::VERSION::STRING < '6.1' ? 2 : 1)
 
 describe Phenix do
   include Phenix


### PR DESCRIPTION
## Description

Dropped unsupported Rails 5.0 and 5.1
Dropped unsupported Ruby 2.4
Bumped Rake for security concern
Fixed deprecation warning in Rails 6.1.0.rc1

