### PR TITLE
Support three tier env configurations

### DIFF
--- a/lib/phenix.rb
+++ b/lib/phenix.rb
@@ -44,7 +44,7 @@ module Phenix
   def create_databases(with_schema)
     for_each_database do |name, conf|
       run_mysql_command(conf, "CREATE DATABASE IF NOT EXISTS #{conf['database']}")
-      ActiveRecord::Base.establish_connection(name.to_sym)
+      ActiveRecord::Base.establish_connection(conf)
       populate_database if with_schema
     end
   end

--- a/lib/phenix.rb
+++ b/lib/phenix.rb
@@ -64,7 +64,15 @@ module Phenix
   end
 
   def for_each_database
-    configuration_hashes = if ActiveRecord::VERSION::STRING < '6.1'
+    parse_configuration_hashes.each do |name, conf|
+      next if conf['database'].nil?
+      next if Phenix.skip_database.call(name, conf)
+      yield(name, conf)
+    end
+  end
+
+  def parse_configuration_hashes
+    if ActiveRecord::VERSION::STRING < '6.1'
       ActiveRecord::Base.configurations.to_h
     else
       # We need to get all the configurations and put them back into a hash
@@ -72,13 +80,6 @@ module Phenix
       ActiveRecord::Base.configurations
         .configurations
         .map { |c| [c.env_name, c.configuration_hash.with_indifferent_access] }
-        .to_h
-    end
-
-    configuration_hashes.each do |name, conf|
-      next if conf['database'].nil?
-      next if Phenix.skip_database.call(name, conf)
-      yield(name, conf)
     end
   end
 

--- a/spec/phenix_spec.rb
+++ b/spec/phenix_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'active_record'
 require 'tmpdir'
@@ -27,6 +28,7 @@ describe Phenix do
 
   let(:simple_database_path)  { File.join(test_directory, 'simple_database.yml') }
   let(:complex_database_path) { File.join(test_directory, 'complex_database.yml') }
+  let(:three_tier_database_path) { File.join(test_directory, 'three_tier_database.yml') }
 
   let(:exists_method)  { (ActiveRecord::VERSION::MAJOR < 5 ? :table_exists? : :data_source_exists?) }
 
@@ -50,6 +52,18 @@ describe Phenix do
 
       expect(Phenix.database_config_path).to eq('my/path/database.yml')
       expect(Phenix.schema_path)         .to eq('my/path/schema.rb')
+    end
+
+    if ActiveRecord::VERSION::STRING >= '6.1'
+      describe :three_tier_database_configs do
+        describe :parse_configuration_hashes do
+          it 'creates configuration_hashes for each database' do
+            load_database_config(three_tier_database_path)
+
+            expect(Phenix.send(:parse_configuration_hashes).length).to eq(ActiveRecord::Base.configurations.configurations.length)
+          end
+        end
+      end
     end
   end
 

--- a/test/three_tier_database.yml
+++ b/test/three_tier_database.yml
@@ -1,0 +1,28 @@
+<% mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306') %>
+
+test:
+  database1:
+    encoding: utf8
+    adapter: mysql2
+    username: <%= mysql.user %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    password: <%= mysql.password %>
+
+  database2:
+    encoding: utf8
+    adapter: mysql2
+    username: <%= mysql.user %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    password: <%= mysql.password %>
+    database: phenix_database_2
+
+  database3:
+    encoding: utf8
+    adapter: mysql2
+    username: <%= mysql.user %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    password: <%= mysql.password %>
+    database: phenix_database_3


### PR DESCRIPTION
I think this is unintentional behavior:

If we have a three tier database configuration with 3 databases in the `test` env then 

```ruby
db_config = ActiveRecord::Base.configurations
        .configurations
        .map { |c| [c.env_name, c.configuration_hash.with_indifferent_access] }
```
Would return:

```ruby
db_config => [
    ["test", {"adapter"=>"mysql2", "encoding"=>"utf8", "username"=>"admin", "password"=>123456, "host"=>"127.0.0.1", "reconnect"=>true, "database"=>"example_1"}], 
    ["test", {"adapter"=>"mysql2", "encoding"=>"utf8", "username"=>"admin", "password"=>123456, "host"=>"127.0.0.1", "reconnect"=>true, "database"=>"example_2"}],
    ["test", {"adapter"=>"mysql2", "encoding"=>"utf8", "username"=>"admin", "password"=>123456, "host"=>"127.0.0.1", "reconnect"=>true, "database"=>"example_3"}]
  ]
```

We used to call `.to_h` on this result which would flatten the array and return:

```ruby
{"test"=>{"adapter"=>"mysql2", "encoding"=>"utf8", "username"=>"admin", "password"=>123456, "host"=>"127.0.0.1", "reconnect"=>true, "database"=>"example_3"}}
```
This has the unintended result of only creating/dropping one database per environment.
