### PR TITLE
[RUBY-588] Separate db create and populate

### DIFF
--- a/lib/phenix.rb
+++ b/lib/phenix.rb
@@ -42,8 +42,14 @@ module Phenix
   private
 
   def create_databases(with_schema)
+    # Ensure we've created _every_ database before attempting to populte them
+    # This avoids ActiveRecord caching issues if the cache maintains references
+    # to stale databases
     for_each_database do |name, conf|
       run_mysql_command(conf, "CREATE DATABASE IF NOT EXISTS #{conf['database']}")
+    end
+
+    for_each_database do |name, conf|
       ActiveRecord::Base.establish_connection(conf)
       populate_database if with_schema
     end


### PR DESCRIPTION
Separate logic of creating databases and setting them up.

This is a patch taken from [active record host pool](https://github.com/zendesk/active_record_host_pool). We need to create all databases before trying to establish a connection so that ActiveRecord doesn't connect to instances from the cache.