### PR TITLE
add publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish public gem
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@ require 'bundler/gem_tasks'
 require 'bump/tasks'
 require 'rspec/core/rake_task'
 
+ENV["gem_push"] = "false"
+
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require 'bundler/gem_tasks'
-require 'bump/tasks'
 require 'rspec/core/rake_task'
 
 ENV["gem_push"] = "false"

--- a/phenix.gemspec
+++ b/phenix.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3.4'
-  s.add_development_dependency 'bump'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'single_cov'
 end


### PR DESCRIPTION
Adds a Github Actions workflow for publishing to RubyGems and sets `ENV["gem_push"]` to false to allow tag creation using `rake release`.