### PR TITLE
Modernize gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
@@ -31,17 +30,6 @@ jobs:
           - rails6.1
           - rails7.0
           - rails7.1
-        include:
-          - ruby-version: "2.5"
-            gemfile: rails4.2
-          - ruby-version: "2.5"
-            gemfile: rails5.0
-          - ruby-version: "2.5"
-            gemfile: rails5.1
-          - ruby-version: "2.7"
-            gemfile: rails5.2
-          - ruby-version: "2.7"
-            gemfile: rails6.0
     name: Ruby ${{ matrix.ruby-version }}, ${{ matrix.gemfile }}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,8 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 4.2.5'
-gem 'mysql2', '>= 0.3.13', '< 0.5'
-
-eval_gemfile 'common.rb'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 5.0.2'
-
-eval_gemfile 'common.rb'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 5.1.0'
-
-eval_gemfile 'common.rb'

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 5.2.0'
-
-eval_gemfile 'common.rb'

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 6.0.0'
-
-eval_gemfile 'common.rb'

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 7.0.0'
+gem 'activerecord', '~> 7.1.0'
 
 eval_gemfile 'common.rb'

--- a/lib/phenix.rb
+++ b/lib/phenix.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'phenix/version'
 require 'erb'
+require 'uri'
 
 module Phenix
   CONFIG_TO_MYSQL_MAPPING = {

--- a/phenix.gemspec
+++ b/phenix.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'bundler'
-  s.add_dependency 'activerecord', '>= 4.2', '< 7.2'
+  s.add_dependency 'activerecord', '>= 6.1'
 
   s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3.4'


### PR DESCRIPTION
- Stop testing with Ruby < 3.1.
- Drops support for ActiveRecord < 6.1.
- Fixes testing with ActiveRecord 7.1.
- Removes upper boundary on ActiveRecord.

I had to add `require 'uri'` to fix Ruby 3.3 testing.